### PR TITLE
More Octogram answers

### DIFF
--- a/octogram.html
+++ b/octogram.html
@@ -208,7 +208,7 @@ levels = [
  
   {required: 30},
 	{gram: "FRTOENJE", ans: "i"},
-	{gram: "ENTOZHIN", ans: "在"},
+	{gram: "ENTOZHIN", ans: "在,里,裡,裏,内"},
 	{gram: "MIIDIOMA", ans: "spanish,español,español"},
 	{gram: "VESTENDO", ans: "italian dressing"},
   {required: 33},
@@ -231,7 +231,7 @@ levels = [
 	{gram: "REDXBLUE", ans: "purple"},
 	{gram: "GOATXEWE", ans: "geep,shoat"},
 	{gram: "HPXDRACO", ans: "drarry"},
-	{gram: "BOXXXMAS", ans: "present"},
+	{gram: "BOXXXMAS", ans: "present,gift"},
 	{gram: "CYAGENTA", ans: "blue"},
 	{gram: "TEQAHLUA", ans: "brave bull"},
 	{gram: "LUNKFAST", ans: "brunch"},


### PR DESCRIPTION
added answers to two Octogram puzzles:
"ENTOZHIN" - more Chinese characters that are more natural/common answers when a Chinese speaker is asked to translate "in" without context. 在 is usually more thought of as "at", but can be left in due to the presumed-intended Google Translate solution path 
"BOXXXMAS" - add "gift" as a synonym for "present"